### PR TITLE
Streamline building and running from the command line

### DIFF
--- a/learn-anything/.eslintrc.json
+++ b/learn-anything/.eslintrc.json
@@ -1,3 +1,15 @@
 {
-  "extends": ["next/core-web-vitals", "next/typescript"]
+  "extends": ["next/core-web-vitals", "next/typescript"],
+  "rules": {
+    // note you must disable the base rule as it can report incorrect errors
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "error", // or "error"
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_"
+      }
+    ]
+  }
 }

--- a/learn-anything/.gitignore
+++ b/learn-anything/.gitignore
@@ -40,3 +40,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+# ignore all but the top-level tsconfig.json file
+**/tsconfig.json
+!/tsconfig.json
+

--- a/learn-anything/package.json
+++ b/learn-anything/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
+    "@ffprobe-installer/ffprobe": "^2.1.2",
     "@langchain/community": "^0.2.31",
     "@langchain/core": "^0.3.6",
     "@langchain/langgraph": "0.2.0",
@@ -20,7 +21,6 @@
     "@pinecone-database/pinecone": "^3.0.3",
     "@types/fluent-ffmpeg": "^2.1.26",
     "dotenv": "^16.4.5",
-    "ffmpeg-static": "^5.2.0",
     "fluent-ffmpeg": "^2.1.3",
     "next": "14.2.15",
     "react": "^18",

--- a/learn-anything/src/server/main.ts
+++ b/learn-anything/src/server/main.ts
@@ -26,8 +26,6 @@ import { StateGraph } from "@langchain/langgraph";
 // other
 import fs from "fs";
 
-import { HumanMessage } from "@langchain/core/messages";
-
 
 const workflow = new StateGraph(GraphState)
     .addNode("toxicityCheck", toxicityCheck)
@@ -62,7 +60,7 @@ const inputs = {
   userInput: "Teach me about the history of the United States",
 };
 
-let finalState;
+let _finalState; // DEBUG
 
 (async () => {
   const image = await representation.drawMermaidPng();
@@ -85,7 +83,7 @@ let finalState;
           tool_calls: lastMsg.tool_calls,
         }, { depth: null });
         console.log("---\n");
-        finalState = value;
+        _finalState = value; // DEBUG
       } else {
         console.warn(`Output from node '${key}' does not contain valid messages. \n\n Here is the output: \n\n ${JSON.stringify(output[key], null, 2)}`);
       }
@@ -93,6 +91,6 @@ let finalState;
   }
 })();
 
-// console.log(JSON.stringify(finalState, null, 2));
+// console.log(JSON.stringify(_finalState, null, 2)); // DEBUG
 
 

--- a/learn-anything/src/server/nodes/audioGenerator/index.ts
+++ b/learn-anything/src/server/nodes/audioGenerator/index.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import OpenAI from "openai";
+import { OpenAI } from "openai";
 import dotenv from "dotenv";
 import { GraphStateType } from "@/server/state";
 dotenv.config();

--- a/learn-anything/src/server/nodes/audioGenerator/index.ts
+++ b/learn-anything/src/server/nodes/audioGenerator/index.ts
@@ -30,7 +30,7 @@ async function generateAudio({sceneText, index}: {sceneText: string, index: numb
     const buffer = Buffer.from(await response.arrayBuffer());
     await fs.promises.writeFile(audioPath, buffer);
 
-    console.log(`Audio content generated for scene ${index}`);
+    console.log(`Audio content generated for scene ${index} at ${audioPath}`);
     return {
       audioPath,
       audioLength: buffer.length / 1000 // Return length in seconds as a rough estimate
@@ -60,15 +60,5 @@ export async function audioGenerator(state: GraphStateType): Promise<Partial<Gra
   };
 }
 
-// async function test() {
-//   try {
-//     await audioGenerator({
-//       scenes: [{ content: "This is a scene audio text", path: undefined, length: undefined, graphicDescription: undefined, manimCode: undefined }]
-//     });
-//     console.log("Audio generation completed successfully.");
-//   } catch (error) {
-//     console.error("Audio generation failed:", error);
-//   }
-// }
-
-// test();
+// async function test(prompt: string) { await generateAudio({ sceneText: prompt, index: 0 }); }
+// test("This is a scene audio text"); // Outputs ./generated_audio/scene_0.mp3

--- a/learn-anything/src/server/nodes/combineScenes/index.ts
+++ b/learn-anything/src/server/nodes/combineScenes/index.ts
@@ -3,9 +3,11 @@ import path from "path";
 import fs from "fs";
 import { GraphStateType } from "src/server/state/index";
 import ffmpegInstaller from "@ffmpeg-installer/ffmpeg";
+import ffprobeInstaller from "@ffprobe-installer/ffprobe";
 
 // Set the ffmpeg binary path
 ffmpeg.setFfmpegPath(ffmpegInstaller.path);
+ffmpeg.setFfprobePath(ffprobeInstaller.path);
 
 // Define output directory for combined videos
 const videoOutputDirectory = path.resolve("./generated_videos");

--- a/learn-anything/src/server/nodes/combineScenes/index.ts
+++ b/learn-anything/src/server/nodes/combineScenes/index.ts
@@ -15,7 +15,7 @@ if (!fs.existsSync(videoOutputDirectory)) {
   fs.mkdirSync(videoOutputDirectory, { recursive: true });
 }
 
-async function combineScene(scene: { imagePath: string, audioPath: string, index: number }): Promise<string> {
+async function composeScene(scene: { imagePath: string, audioPath: string, index: number }): Promise<string> {
   const { imagePath, audioPath, index } = scene;
 
   // Define the output path for the scene video
@@ -36,6 +36,11 @@ async function combineScene(scene: { imagePath: string, audioPath: string, index
         .loop(audioDuration)  // Loop the image for the duration of the audio
         .input(audioPath)     // Input audio
         .outputOptions("-c:v libx264")  // Encode to h264 for video
+        .outputOptions("-preset veryfast") // Set encoding speed
+        .outputOptions("-movflags faststart")                // Optimize for streaming
+        .outputOptions("-movflags frag_keyframe+empty_moov") // Optimize for streaming
+        .outputOptions("-level:v 4.0")     // Set video level for compatibility with most devices
+        .outputOptions("-profile:v main")  // Set video profile for compatibility with most devices
         .outputOptions("-pix_fmt yuv420p") // Ensure compatibility for most video players
         .outputOptions("-c:a aac")  // Encode to AAC for audio
         .outputOptions(`-t ${audioDuration}`)  // Set the duration of the video to match the audio
@@ -62,7 +67,7 @@ export async function combineScenes(state: GraphStateType): Promise<Partial<Grap
     const { imagePath, audioPath } = scene;
     if (imagePath && audioPath) {
       try {
-        const videoPath = await combineScene({ imagePath, audioPath, index });
+        const videoPath = await composeScene({ imagePath, audioPath, index });
         videoPaths.push(videoPath);
       } catch (error) {
         console.error(`Failed to combine scene ${index}:`, error);

--- a/learn-anything/src/server/nodes/presentationGenerator/index.ts
+++ b/learn-anything/src/server/nodes/presentationGenerator/index.ts
@@ -33,7 +33,10 @@ export async function createPresentation(state: GraphStateType): Promise<Partial
     }
 }
 
-// async function test() {
-// await createPresentation({scenes: [{content: "this is a scene"}, {content: "this is another scene"}, {content: "this is a third scene"}]})
+// async function test(scenes: string[]) {
+//   const state: GraphStateType = {
+//     scenes: scenes.map(scene => ({content: scene})),
+//   }
+//   await createPresentation(state)
 // }
-// test()
+// test(["this is a scene", "this is another scene", "this is a third scene"])

--- a/learn-anything/src/server/nodes/presentationGenerator/index.ts
+++ b/learn-anything/src/server/nodes/presentationGenerator/index.ts
@@ -1,5 +1,5 @@
 import { GraphStateType } from "@/server/state";
-import { model } from "src/server/models/chatModel";
+import { model } from "../../models/chatModel";
 import { ChatPromptTemplate } from "@langchain/core/prompts";
 
 // Define the chat prompt template for transcript creation

--- a/learn-anything/src/server/nodes/presentationGenerator/index.ts
+++ b/learn-anything/src/server/nodes/presentationGenerator/index.ts
@@ -1,4 +1,4 @@
-import { GraphStateType } from "src/server/state/index";
+import { GraphStateType } from "@/server/state";
 import { model } from "src/server/models/chatModel";
 import { ChatPromptTemplate } from "@langchain/core/prompts";
 
@@ -16,7 +16,7 @@ const presentationModel = presentationPromptTemplate.pipe(model);
 export async function createPresentation(state: GraphStateType): Promise<Partial<GraphStateType>> {
   console.log("running createPresentation")
     const {scenes} = state;
-    const scenesWithDesc = await Promise.all(scenes.map(async (scene, index) => {
+    const scenesWithDesc = await Promise.all(scenes.map(async (scene) => {
       const response = await presentationModel.invoke({scene: scene.content});
       // console.log("response", response)
       return {

--- a/learn-anything/src/server/nodes/transcriptCreator/index.ts
+++ b/learn-anything/src/server/nodes/transcriptCreator/index.ts
@@ -44,9 +44,9 @@ function splitContent(content: string): SceneDetails[] {
 }
 
 
-// async function test() {
-//   const state = {generatedContent: "Content about 'The Water Cycle Explained': Discuss the processes of evaporation, condensation, precipitation, and collection in the water cycle, and explain how they contribute to Earth's ecosystem."}
+// async function test(prompt: string) {
+//   const state = {generatedContent: prompt}
 //   const response = await createTranscript(state);
 //   console.log(response);
 // }
-// test()
+// test("Content about 'The Water Cycle Explained': Discuss the processes of evaporation, condensation, precipitation, and collection in the water cycle, and explain how they contribute to Earth's ecosystem.")

--- a/learn-anything/src/server/nodes/visualGenerator/index.ts
+++ b/learn-anything/src/server/nodes/visualGenerator/index.ts
@@ -16,7 +16,7 @@ if (!fs.existsSync(imageOutputDirectory)) {
   fs.mkdirSync(imageOutputDirectory, { recursive: true });
 }
 
-async function saveImage({ prompt, index }: { prompt: string, index: number }) {
+async function generateImage({ prompt, index }: { prompt: string, index: number }) {
   console.log(`Generating image for scene ${index}`);
 
   try {
@@ -99,7 +99,7 @@ export async function imageGenerator(state: GraphStateType): Promise<Partial<Gra
       throw new Error(`Scene ${index} does not have a graphic description`);
     }
     // generate image for the scene
-    const { imagePath } = await saveImage({ prompt: scene.graphicDescription, index });
+    const { imagePath } = await generateImage({ prompt: scene.graphicDescription, index });
 
     return {
       ...scene,
@@ -111,3 +111,6 @@ export async function imageGenerator(state: GraphStateType): Promise<Partial<Gra
     scenes: updatedScenes,
   };
 }
+
+// async function test(prompt: string) { await generateImage({ prompt, index: 0 }); }
+// test("a white siamese cat"); // Outputs ./generated_images/scene_0.png

--- a/learn-anything/src/server/nodes/visualGenerator/index.ts
+++ b/learn-anything/src/server/nodes/visualGenerator/index.ts
@@ -1,9 +1,8 @@
 import fs from "fs";
 import path from "path";
-import {OpenAI} from "openai"; // Assuming OpenAI is your image generation source
+import { OpenAI } from "openai";
 import dotenv from "dotenv";
-import { DallEAPIWrapper } from "@langchain/openai";
-import { GraphStateType } from "src/server/state/index";
+import { GraphStateType } from "@/server/state";
 dotenv.config();
 
 const openai = new OpenAI();

--- a/learn-anything/src/server/nodes/visualGenerator/index.ts
+++ b/learn-anything/src/server/nodes/visualGenerator/index.ts
@@ -25,7 +25,7 @@ async function generateImage({ prompt, index }: { prompt: string, index: number 
       model: "dall-e-3",    // First try with DALL-E 3
       prompt: prompt,       // Prompt for the image
       n: 1,                 // Generate one image
-      size: "1024x1024",    // Image size
+      size: "1024x1024",    // Image size (half HD)
     });
 
     // Get the URL of the generated image

--- a/learn-anything/src/server/state/index.ts
+++ b/learn-anything/src/server/state/index.ts
@@ -1,6 +1,4 @@
 import { Annotation } from "@langchain/langgraph";
-import { Document } from "@langchain/core/documents";
-import { BaseMessage } from "@langchain/core/messages";
 
 // very bad way of doing this but it works for now
 export type SceneDetails = {

--- a/learn-anything/yarn.lock
+++ b/learn-anything/yarn.lock
@@ -14,16 +14,6 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@derhuerst/http-basic@^8.2.0":
-  version "8.2.4"
-  resolved "https://registry.yarnpkg.com/@derhuerst/http-basic/-/http-basic-8.2.4.tgz#d021ebb8f65d54bea681ae6f4a8733ce89e7f59b"
-  integrity sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==
-  dependencies:
-    caseless "^0.12.0"
-    concat-stream "^2.0.0"
-    http-response-object "^3.0.1"
-    parse-cache-control "^1.0.1"
-
 "@esbuild/aix-ppc64@0.19.12":
   version "0.19.12"
   resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz#d1bc06aedb6936b3b6d313bf809a5a40387d2b7f"
@@ -224,6 +214,60 @@
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@ffmpeg-installer/win32-x64/-/win32-x64-4.1.0.tgz#17e8699b5798d4c60e36e2d6326a8ebe5e95a2c5"
   integrity sha512-Drt5u2vzDnIONf4ZEkKtFlbvwj6rI3kxw1Ck9fpudmtgaZIHD4ucsWB2lCZBXRxJgXR+2IMSti+4rtM4C4rXgg==
+
+"@ffprobe-installer/darwin-arm64@5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@ffprobe-installer/darwin-arm64/-/darwin-arm64-5.0.1.tgz#a020a623955d55aa8daf45cb668c3044876b553b"
+  integrity sha512-vwNCNjokH8hfkbl6m95zICHwkSzhEvDC3GVBcUp5HX8+4wsX10SP3B+bGur7XUzTIZ4cQpgJmEIAx6TUwRepMg==
+
+"@ffprobe-installer/darwin-x64@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@ffprobe-installer/darwin-x64/-/darwin-x64-5.1.0.tgz#f52316ac0bbe6f4ac70fdaea8db259ba4a055b00"
+  integrity sha512-J+YGscZMpQclFg31O4cfVRGmDpkVsQ2fZujoUdMAAYcP0NtqpC49Hs3SWJpBdsGB4VeqOt5TTm1vSZQzs1NkhA==
+
+"@ffprobe-installer/ffprobe@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@ffprobe-installer/ffprobe/-/ffprobe-2.1.2.tgz#ef9826b714cefe5e2debbe357afbb1ba738dfb32"
+  integrity sha512-ZNvwk4f2magF42Zji2Ese16SMj9BS7Fui4kRjg6gTYTxY3gWZNpg85n4MIfQyI9nimHg4x/gT6FVkp/bBDuBwg==
+  optionalDependencies:
+    "@ffprobe-installer/darwin-arm64" "5.0.1"
+    "@ffprobe-installer/darwin-x64" "5.1.0"
+    "@ffprobe-installer/linux-arm" "5.2.0"
+    "@ffprobe-installer/linux-arm64" "5.2.0"
+    "@ffprobe-installer/linux-ia32" "5.2.0"
+    "@ffprobe-installer/linux-x64" "5.2.0"
+    "@ffprobe-installer/win32-ia32" "5.1.0"
+    "@ffprobe-installer/win32-x64" "5.1.0"
+
+"@ffprobe-installer/linux-arm64@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@ffprobe-installer/linux-arm64/-/linux-arm64-5.2.0.tgz#b6cb3735792d9d012d1caba4de2a6f90af2a8966"
+  integrity sha512-X1VvWtlLs6ScP73biVLuHD5ohKJKsMTa0vafCESOen4mOoNeLAYbxOVxDWAdFz9cpZgRiloFj5QD6nDj8E28yQ==
+
+"@ffprobe-installer/linux-arm@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@ffprobe-installer/linux-arm/-/linux-arm-5.2.0.tgz#0120863c181303a1610b1e6956c6a5492d6c45a6"
+  integrity sha512-PF5HqEhCY7WTWHtLDYbA/+rLS+rhslWvyBlAG1Fk8VzVlnRdl93o6hy7DE2kJgxWQbFaR3ZktPQGEzfkrmQHvQ==
+
+"@ffprobe-installer/linux-ia32@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@ffprobe-installer/linux-ia32/-/linux-ia32-5.2.0.tgz#d42a892003811b5e1f2c958d330b841ef6ff3233"
+  integrity sha512-TFVK5sasXyXhbIG7LtPRDmtkrkOsInwKcL43iEvEw+D9vCS2rc//mn9/0Q+BR0UoJEiMK4+ApYr/3LLVUBPOCQ==
+
+"@ffprobe-installer/linux-x64@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@ffprobe-installer/linux-x64/-/linux-x64-5.2.0.tgz#5dd8dbd51d130b5997bf49cb874e1f92e97f02e7"
+  integrity sha512-D3UeqTLYPNs7pBWPLUYGehPdRVqU8eACox4OZy3pZUZatxye2YKlvBwEfaLdL1v2Z4FOAlLUhms0kY8m8kqSRA==
+
+"@ffprobe-installer/win32-ia32@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@ffprobe-installer/win32-ia32/-/win32-ia32-5.1.0.tgz#43b1462b9d89570fe3723c20b66bab684516751a"
+  integrity sha512-5O3vOoNRxmut0/Nu9vSazTdSHasrr+zPT2B3Hm7kjmO3QVFcIfVImS6ReQnZeSy8JPJOqXts5kX5x/3KOX54XQ==
+
+"@ffprobe-installer/win32-x64@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@ffprobe-installer/win32-x64/-/win32-x64-5.1.0.tgz#87841123e8b903cc327f1e5b9aa69e5d2fbe6d7b"
+  integrity sha512-jMGYeAgkrdn4e2vvYt/qakgHRE3CPju4bn5TmdPfoAm1BlX1mY9cyMd8gf5vSzI8gH8Zq5WQAyAkmekX/8TSTg==
 
 "@humanwhocodes/config-array@^0.13.0":
   version "0.13.0"
@@ -567,11 +611,6 @@
   dependencies:
     undici-types "~6.19.2"
 
-"@types/node@^10.0.3":
-  version "10.17.60"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
-  integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
-
 "@types/node@^18.11.18":
   version "18.19.55"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.55.tgz#29c3f8e1485a92ec96636957ddec55aabc6e856e"
@@ -725,13 +764,6 @@ acorn@^8.11.0, acorn@^8.4.1, acorn@^8.9.0:
   version "8.12.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.12.1.tgz#71616bdccbe25e27a54439e0046e89ca76df2248"
   integrity sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==
-
-agent-base@6:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
-  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
-  dependencies:
-    debug "4"
 
 agentkeepalive@^4.2.1:
   version "4.5.0"
@@ -970,11 +1002,6 @@ braces@^3.0.3, braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
-buffer-from@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
-  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
-
 busboy@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"
@@ -1012,11 +1039,6 @@ caniuse-lite@^1.0.30001579:
   version "1.0.30001668"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001668.tgz#98e214455329f54bf7a4d70b49c9794f0fbedbed"
   integrity sha512-nWLrdxqCdblixUO+27JtGJJE/txpJlyUy5YN1u53wLZkP0emYCo5zgS6QYft7VUYR42LGgi/S5hdLZTrnyIddw==
-
-caseless@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
-  integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
 
 chalk@^4.0.0:
   version "4.1.2"
@@ -1080,16 +1102,6 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-concat-stream@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-2.0.0.tgz#414cf5af790a48c60ab9be4527d56d5e41133cb1"
-  integrity sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==
-  dependencies:
-    buffer-from "^1.0.0"
-    inherits "^2.0.3"
-    readable-stream "^3.0.2"
-    typedarray "^0.0.6"
-
 create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
@@ -1146,19 +1158,19 @@ data-view-byte-offset@^1.0.0:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
-debug@4, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5:
-  version "4.3.7"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.7.tgz#87945b4151a011d76d95a198d7111c865c360a52"
-  integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
-  dependencies:
-    ms "^2.1.3"
-
 debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5:
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.7.tgz#87945b4151a011d76d95a198d7111c865c360a52"
+  integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
+  dependencies:
+    ms "^2.1.3"
 
 decamelize@1.2.0:
   version "1.2.0"
@@ -1293,11 +1305,6 @@ enhanced-resolve@^5.15.0:
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
-
-env-paths@^2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
-  integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
 
 es-abstract@^1.17.5, es-abstract@^1.22.1, es-abstract@^1.22.3, es-abstract@^1.23.0, es-abstract@^1.23.1, es-abstract@^1.23.2, es-abstract@^1.23.3:
   version "1.23.3"
@@ -1724,16 +1731,6 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
-ffmpeg-static@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/ffmpeg-static/-/ffmpeg-static-5.2.0.tgz#6ca64a5ed6e69ec4896d175c1f69dd575db7c5ef"
-  integrity sha512-WrM7kLW+do9HLr+H6tk7LzQ7kPqbAgLjdzNE32+u3Ff11gXt9Kkkd2nusGFrlWMIe+XaA97t+I8JS7sZIrvRgA==
-  dependencies:
-    "@derhuerst/http-basic" "^8.2.0"
-    env-paths "^2.2.0"
-    https-proxy-agent "^5.0.0"
-    progress "^2.0.3"
-
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
@@ -1999,21 +1996,6 @@ hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
-http-response-object@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/http-response-object/-/http-response-object-3.0.2.tgz#7f435bb210454e4360d074ef1f989d5ea8aa9810"
-  integrity sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==
-  dependencies:
-    "@types/node" "^10.0.3"
-
-https-proxy-agent@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
-  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
-  dependencies:
-    agent-base "6"
-    debug "4"
-
 humanize-ms@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
@@ -2054,7 +2036,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3:
+inherits@2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2752,11 +2734,6 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
-parse-cache-control@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/parse-cache-control/-/parse-cache-control-1.0.1.tgz#8eeab3e54fa56920fe16ba38f77fa21aacc2d74e"
-  integrity sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==
-
 path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
@@ -2877,11 +2854,6 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-progress@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
-  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
-
 prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
@@ -2927,15 +2899,6 @@ read-cache@^1.0.0:
   integrity sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==
   dependencies:
     pify "^2.3.0"
-
-readable-stream@^3.0.2:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
-  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -3028,11 +2991,6 @@ safe-array-concat@^1.1.2:
     get-intrinsic "^1.2.4"
     has-symbols "^1.0.3"
     isarray "^2.0.5"
-
-safe-buffer@~5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-regex-test@^1.0.3:
   version "1.0.3"
@@ -3131,8 +3089,16 @@ streamsearch@^1.1.0:
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
-  name string-width-cjs
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3212,14 +3178,14 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
-    safe-buffer "~5.2.0"
+    ansi-regex "^5.0.1"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -3439,11 +3405,6 @@ typed-array-length@^1.0.6:
     is-typed-array "^1.1.13"
     possible-typed-array-names "^1.0.0"
 
-typedarray@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
-  integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
-
 typescript@*, typescript@^5:
   version "5.6.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.3.tgz#5f3449e31c9d94febb17de03cc081dd56d81db5b"
@@ -3476,7 +3437,7 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-util-deprecate@^1.0.1, util-deprecate@^1.0.2:
+util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==


### PR DESCRIPTION
Fix failures when you try to run with `yarn run-agent` or `yarn build`. I also made sure debug test code in each subordinate xxGenerator.ts node could be uncommented and invoked with `ebx path/to/index.ts -r --ignore-types`.
(Note: This debug code could be turned into unit tests!)

## Details…

- Fix yarn run-agent execution errors

  Problem: `yarn run-agent` failed with an error in `src/server/main.ts`:
  ```
  Could not resolve "src/server/models/chatModel"
  ```

  Solution: Use a relative path for the import.

  Problem: `yarn run-agent` failed with ffprobe errors

  Solution: Install fluent-ffprobe dependency to determine the length of a video scene. Remove the redundant, unused ffmpeg-static dependency.

- Tweak debug test code for generator nodes: transcript, presentation, visual, audio

  You can run any script by un-commenting the few lines of test code at the bottom of the script and running the script with `ebx`:
  ```
  cd learn-anything
  ebx src/server/nodes/visualGenerator/index.ts -r --ignore-types
  ```
  Note: We should convert these debug/test lines into actual unit test code (with Jest?).

  Only ignore tsconfig.json files that node/ebx leaves in subdirectories if you forget to run a script from the learn-anything directory.
  ```
  cd src/server/nodes/some_node
  ebx index.ts -r --ignore-types
  ```

- Improve speed of video generation, streaming with encoding tweaks

  `-preset veryfast` shaves 1-2 seconds off the movie generation time.

- Cleanup: Fix linting errors flagged by `yarn lint`
